### PR TITLE
chore: add .gitignore for Python artifacts and env files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+__pycache__/
+*.pyc
+
+# Virtual environments
+.venv/
+venv/
+env/
+
+# macOS
+.DS_Store


### PR DESCRIPTION
## Summary
- add .gitignore ignoring Python caches, virtualenvs, and macOS artifacts

## Testing
- `pre-commit run --files .gitignore` *(fails: CalledProcessError: command: ('/usr/bin/git', 'fetch', 'origin', '--tags') return code: 128)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bc0d549994832883084090f80bddf5