### PR TITLE
chore: set python 3.11

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 default_language_version:
-  python: python3.10
+  python: python3.11
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["<lithvf@gmail.com>"]
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = "^3.9"
+python = "3.11.*"
 pandas = "^2.2.3"
 ipykernel = "^6.29.5"
 pylint = "^3.3.5"


### PR DESCRIPTION
## Summary
- target Python 3.11

## Testing
- `pre-commit run --files pyproject.toml .pre-commit-config.yaml` *(fails: fatal: unable to access 'https://github.com/pre-commit/pre-commit-hooks/': CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68bebd2d4e4083288a2d5ff8238b4c40