### PR TITLE
Add VS Code Black formatter settings and template metadata

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "python.formatting.provider": "black",
+    "editor.formatOnSave": true
+}

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Project structure
 ```bash
-<project_name>/
+template-project/
 ├── README.md               # Project overview and instructions
 ├── config.yaml             # Configuration for model and features
 ├── poetry.lock             # Poetry lock file (dependencies)
@@ -14,8 +14,8 @@
 ## Installation
 
 ```bash
-git clone https://github.com/<user>/<project>.git
-cd <project>
+git clone https://github.com/template-user/template-project.git
+cd template-project
 pip install poetry
 poetry env use python
 poetry install

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,8 @@
 [tool.poetry]
-name = "ml-e"
+name = "template-project"
 version = "1"
 description = "hobby repository"
-authors = ["<lithvf@gmail.com>"]
+authors = ["template-user <user@example.com>"]
 readme = "README.md"
 
 [tool.poetry.dependencies]


### PR DESCRIPTION
## Summary
- Add VS Code settings enabling Black and format-on-save
- Rename project and author fields to template values

## Testing
- ⚠️ `pre-commit run --files .vscode/settings.json README.md pyproject.toml` *(dependency installation failed: ProxyError, command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c10e97bf8c8328bd469d67c1d7b9c3